### PR TITLE
feat: Standardize CLI filtering and add empty name pattern support

### DIFF
--- a/yanex/cli/filters/base.py
+++ b/yanex/cli/filters/base.py
@@ -183,8 +183,14 @@ class ExperimentFilter:
     def _matches_name_pattern(self, experiment: Dict[str, Any], pattern: str) -> bool:
         """Check if experiment name matches glob pattern."""
         name = experiment.get("name", "")
+        original_name = name
+        
+        # Special case: empty pattern should match empty names
+        if not pattern:
+            return not original_name
+        
         if not name:
-            # Handle unnamed experiments
+            # Handle unnamed experiments - convert to searchable form
             name = "[unnamed]"
         return fnmatch.fnmatch(name.lower(), pattern.lower())
 


### PR DESCRIPTION
- Standardize list command to use consistent --*-before/--*-after time filters
- Add support for filtering unnamed experiments with empty pattern ""
- Enhanced name filtering with comprehensive edge case handling
- Added unit tests for empty name pattern matching
- Updated help documentation with examples

Changes:
- yanex/cli/commands/list.py: Updated to use --started-after/--started-before etc.
- yanex/cli/filters/base.py: Added empty pattern matching for unnamed experiments
- tests/cli/test_filters.py: Added comprehensive tests for empty name filtering

Examples:
  yanex list --name ""                    # Find unnamed experiments
  yanex list --started-after "last week" # Consistent time filtering
  yanex list --name "*test*"             # Standard glob patterns

🤖 Generated with [Claude Code](https://claude.ai/code)