### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-03-04
+
 ### Breaking Changes
 
 - **Removed TrackedDict and parameter access tracking**: `get_params()` now returns a plain dict. `params.yaml` is written once at experiment creation and never overwritten. Removed `TrackedDict`, atexit handler, `ParameterConflictError`, `from_dependency` parameter (~3200 lines removed)
 - **Storage version bumped to v2**: New `project` field in experiment metadata. Run `yanex migrate --all` to update existing experiments
 
 ### Added
+
+- **Experiment Syncing (Push/Pull)**: Sync experiments between machines via SSH or S3
+  - `yanex push <target>` and `yanex pull <target>` commands
+  - SSH targets use `rsync` with `~/.ssh/config` aliases; S3 targets use `aws s3 sync`
+  - Full filtering API on both push and pull (`--name`, `--status`, `--tag`, `--ids`, etc.)
+  - Pull reads remote metadata first to apply filters before transferring
+  - `--progress` flag for transfer progress display
+  - Global scope by default; confirmation prompt with `--yes/-y` to skip
+  - Zero new Python dependencies (shells out to `rsync` and `aws` CLI)
 
 - **Project-Scoped Experiments**: Experiments are automatically associated with a project derived from the git repo name
   - Filter commands (`list`, `delete`, `archive`, etc.) default to current project's experiments

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**Yanex** (Yet Another Experiment Tracker) is a lightweight, Git-aware experiment tracking system for Python designed for machine learning and research reproducibility. It's currently in alpha (v0.6.0a4) and provides CLI, Python API, and web UI interfaces.
+**Yanex** (Yet Another Experiment Tracker) is a lightweight, Git-aware experiment tracking system for Python designed for machine learning and research reproducibility. It's at v0.6.0 and provides CLI, Python API, and web UI interfaces.
 
 ## Essential Commands
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yanex"
-version = "0.6.0a4"
+version = "0.6.0"
 description = "Yet Another Experiment Tracker - A lightweight experiment tracking harness"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -26,7 +26,7 @@ class TestCLIMain:
         """Test CLI version output."""
         result = self.runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
-        assert "0.1.0" in result.output
+        assert "0.6.0" in result.output
 
     def test_run_command_help(self):
         """Test run command help."""

--- a/uv.lock
+++ b/uv.lock
@@ -1606,7 +1606,7 @@ wheels = [
 
 [[package]]
 name = "yanex"
-version = "0.6.0a4"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/yanex/__init__.py
+++ b/yanex/__init__.py
@@ -58,7 +58,7 @@ from .core.artifact_formats import register_format
 from .executor import ExperimentResult, ExperimentSpec, run_multiple
 from .results.experiment import Experiment
 
-__version__ = "0.6.0a3"
+__version__ = "0.6.0"
 __author__ = "Thomas"
 
 __all__ = [

--- a/yanex/cli/main.py
+++ b/yanex/cli/main.py
@@ -21,7 +21,7 @@ from .commands.update import update_experiments
 
 
 @click.group()
-@click.version_option(version="0.1.0", prog_name="yanex")
+@click.version_option(version="0.6.0", prog_name="yanex")
 @click.option("--verbose", "-v", is_flag=True, help="Enable verbose output")
 @click.pass_context
 def cli(ctx: click.Context, verbose: bool) -> None:

--- a/yanex/web/app.py
+++ b/yanex/web/app.py
@@ -15,7 +15,7 @@ from .api import router as api_router
 app = FastAPI(
     title="Yanex Web UI",
     description="Web interface for yanex experiment tracking",
-    version="0.6.0a3",
+    version="0.6.0",
 )
 
 # Include API routes first (highest priority)


### PR DESCRIPTION
## Summary

- Bump version from `0.6.0a4` to `0.6.0` across all files (pyproject.toml, `__init__.py`, CLI `--version`, web app, CLAUDE.md)
- Fix stale CLI version (`0.1.0` → `0.6.0`)
- Finalize CHANGELOG.md for v0.6.0 release (adds push/pull syncing entry, dates the release)
- Sync uv.lock
- Update version assertion in test

🤖 Generated with [Claude Code](https://claude.com/claude-code)