### PR TITLE
Handle missing git state gracefully

### DIFF
--- a/tests/cli/test_run_error_handling.py
+++ b/tests/cli/test_run_error_handling.py
@@ -1,5 +1,7 @@
 """Tests for yanex run command error handling and validation."""
 
+import git
+
 from tests.test_utils import TestFileHelpers
 from yanex.cli.main import cli
 
@@ -84,6 +86,51 @@ class TestRunCommandErrorHandling:
         assert result.exit_code == 0
         # Verbose mode should show running script message
         # (This tests lines 226-236 in run.py)
+
+    def test_run_in_unborn_git_repository(
+        self, tmp_path, cli_runner, monkeypatch, per_test_experiments_dir
+    ):
+        """Test run works in a git repository with no commits yet."""
+        git.Repo.init(tmp_path)
+        script_path = TestFileHelpers.create_test_script(tmp_path, "test.py", "simple")
+        monkeypatch.chdir(tmp_path)
+
+        result = cli_runner.invoke(cli, ["run", str(script_path)])
+
+        assert result.exit_code == 0, result.output
+        assert "Experiment completed successfully:" in result.output
+
+        from yanex.core.manager import ExperimentManager
+
+        manager = ExperimentManager(per_test_experiments_dir)
+        experiments = manager.storage.list_experiments()
+        assert len(experiments) == 1
+        metadata = manager.storage.load_metadata(experiments[0])
+        assert metadata["status"] == "completed"
+        assert metadata["git"]["has_uncommitted_changes"] is False
+        assert metadata["git"]["patch_file"] is None
+
+    def test_run_outside_git_repository(
+        self, tmp_path, cli_runner, monkeypatch, per_test_experiments_dir
+    ):
+        """Test run works when there is no git repository at all."""
+        script_path = TestFileHelpers.create_test_script(tmp_path, "test.py", "simple")
+        monkeypatch.chdir(tmp_path)
+
+        result = cli_runner.invoke(cli, ["run", str(script_path)])
+
+        assert result.exit_code == 0, result.output
+        assert "Experiment completed successfully:" in result.output
+
+        from yanex.core.manager import ExperimentManager
+
+        manager = ExperimentManager(per_test_experiments_dir)
+        experiments = manager.storage.list_experiments()
+        assert len(experiments) == 1
+        metadata = manager.storage.load_metadata(experiments[0])
+        assert metadata["status"] == "completed"
+        assert metadata["git"]["has_uncommitted_changes"] is False
+        assert metadata["git"]["patch_file"] is None
 
     def test_failed_experiments_in_sweep_summary(self, tmp_path, cli_runner):
         """Test that sweep summary shows failed experiments."""

--- a/tests/core/test_environment.py
+++ b/tests/core/test_environment.py
@@ -144,6 +144,20 @@ class TestCaptureGitEnvironment:
         assert "error" in result
         assert "Git repository not found" in result["error"]
 
+    def test_capture_git_environment_unborn_repo(self, temp_dir):
+        """Test capturing git environment before the first commit."""
+        import git
+
+        git.Repo.init(temp_dir)
+
+        result = capture_git_environment(temp_dir)
+
+        assert isinstance(result, dict)
+        assert result["repository"] is None
+        assert result["commit"] is None
+        assert result["git_version"] is None
+        assert "error" in result
+
     @pytest.mark.parametrize(
         "mock_repo_info,mock_commit_info,git_version",
         [

--- a/tests/core/test_git_utils.py
+++ b/tests/core/test_git_utils.py
@@ -513,6 +513,13 @@ class TestGetCurrentCommitInfo:
             with pytest.raises(GitError, match="Failed to get commit info"):
                 get_current_commit_info()
 
+    def test_get_commit_info_unborn_repository(self, tmp_path):
+        """Test unborn git repositories are reported as unavailable commit info."""
+        git.Repo.init(tmp_path)
+
+        with pytest.raises(GitError, match="No commits found"):
+            get_current_commit_info(get_git_repo(tmp_path))
+
     def test_get_commit_info_detached_head(self):
         """Test getting commit info when in detached HEAD state."""
         with patch("yanex.core.git_utils.get_git_repo") as mock_get_repo:

--- a/yanex/core/environment.py
+++ b/yanex/core/environment.py
@@ -75,7 +75,7 @@ def capture_git_environment(repo_path: Path | None = None) -> dict[str, Any]:
 
         return git_info
 
-    except GitError:
+    except (GitError, git.GitError, ValueError, TypeError):
         # If we can't get git info, return minimal info
         return {
             "repository": None,

--- a/yanex/core/git_utils.py
+++ b/yanex/core/git_utils.py
@@ -158,6 +158,9 @@ def get_current_commit_info(repo: Repo | None = None) -> dict[str, str]:
         repo = get_git_repo()
 
     try:
+        if not repo.head.is_valid():
+            raise GitError("No commits found in git repository")
+
         commit = repo.head.commit
 
         return {
@@ -169,7 +172,9 @@ def get_current_commit_info(repo: Repo | None = None) -> dict[str, str]:
             "committed_date": commit.committed_datetime.isoformat(),
         }
 
-    except git.GitError as e:
+    except GitError:
+        raise
+    except (git.GitError, ValueError, TypeError) as e:
         raise GitError(f"Failed to get commit info: {e}") from e
 
 


### PR DESCRIPTION
Fixes the issue when git is not initialised. 

```
> yanex run train.py
Failed to capture git info: ValueError: Reference at 'refs/heads/main' does not exist
Error: Reference at 'refs/heads/main' does not exist
Aborted!
```